### PR TITLE
bug with new lines in the readme files from the github editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
 # furry-guacamole
 Test repo for pass password files
+
 This should be a good description. 


### PR DESCRIPTION
I removed the stupid extra return and then the github editor removed two, so that then the lines continued.